### PR TITLE
Use more specific summary text description for GetRemoteJsonKey

### DIFF
--- a/SharedProcessors/GetRemoteJsonKey.py
+++ b/SharedProcessors/GetRemoteJsonKey.py
@@ -48,7 +48,7 @@ class GetRemoteJsonKey(URLGetter):
         
         self.output(f"Extracted value for '{key}': {extracted_value}")
         self.env["get_remote_json_key_summary_result"] = {
-                "summary_text": "The following new items were downloaded:",
+                "summary_text": "JSON keys were extracted from the following URLs:",
                 "data": {"downloaded_json": url},
             }
 


### PR DESCRIPTION
This will distinguish the summary text from other summaries such as URLDownloader's.

Output before the change:

```
The following new items were downloaded:
    Downloaded Json                                                                    
    ---------------                                                                    
    https://www.cursor.com/api/download?platform=darwin-universal&releaseTrack=stable  
```

After the change:

```
JSON keys were extracted from the following URLs:
    Downloaded Json                                                                    
    ---------------                                                                    
    https://www.cursor.com/api/download?platform=darwin-universal&releaseTrack=stable  
```