### PR TITLE
Revert to URLTextSearcher for parsing Cursor JSON

### DIFF
--- a/Cursor/Cursor.download.recipe.yaml
+++ b/Cursor/Cursor.download.recipe.yaml
@@ -8,15 +8,14 @@ Input:
   NAME: Cursor
 MinimumVersion: '2.3'
 Process:
-- Processor: com.github.discentem.SharedProcessors/GetRemoteJsonKey
+- Processor: URLTextSearcher
   Arguments:
     url: https://www.cursor.com/api/download?platform=darwin-universal&releaseTrack=stable
-    key: downloadUrl
-    output_variable: final_url
+    re_pattern: '(https://[^"]*darwin/universal/[^"]*\.dmg)'
 - Processor: URLDownloader
   Arguments:
     filename: '%NAME%.dmg'
-    url: '%final_url%'
+    url: '%match%'
 - Processor: CodeSignatureVerifier
   Arguments:
     input_path: '%pathname%/Cursor.app'


### PR DESCRIPTION
The GetRemoteJsonKey processor is failing because the Cursor API endpoint doesn't return pure JSON. Instead, it returns URLs wrapped in escaped JSON that looks like this:

```
\"downloadUrl\":\"https://downloads.cursor.com/production/b753cece5c67c47cb5637199a5a5de2b7100c18f/darwin/x64/Cursor-darwin-x64.dmg\"
```

The GetRemoteJsonKey processor could probably be adjusted to detect and work around this condition. However I found it simpler to revert to URLTextSearcher for now, which gets the recipe back up and working:

```
% autopkg run -vv --ignore-parent-trust-verification Cursor/Cursor.download.recipe.yaml
Processing Cursor/Cursor.download.recipe.yaml...
WARNING: Cursor/Cursor.download.recipe.yaml is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '(https://[^"]*darwin/universal/[^"]*\\.dmg)',
           'url': 'https://www.cursor.com/api/download?platform=darwin-universal&releaseTrack=stable'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): https://downloads.cursor.com/production/b753cece5c67c47cb5637199a5a5de2b7100c18f/darwin/universal/Cursor-darwin-universal.dmg
{'Output': {'match': 'https://downloads.cursor.com/production/b753cece5c67c47cb5637199a5a5de2b7100c18f/darwin/universal/Cursor-darwin-universal.dmg'}}
URLDownloader
{'Input': {'filename': 'Cursor.dmg',
           'url': 'https://downloads.cursor.com/production/b753cece5c67c47cb5637199a5a5de2b7100c18f/darwin/universal/Cursor-darwin-universal.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Fri, 19 Sep 2025 18:18:43 GMT
URLDownloader: Storing new ETag header: "a9b14fad843592cb5558cdc5d38e2712-48"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.peetinc.download.Cursor/downloads/Cursor.dmg
{'Output': {'download_changed': True,
            'etag': '"a9b14fad843592cb5558cdc5d38e2712-48"',
            'last_modified': 'Fri, 19 Sep 2025 18:18:43 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.peetinc.download.Cursor/downloads/Cursor.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.peetinc.download.Cursor/downloads/Cursor.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.peetinc.download.Cursor/downloads/Cursor.dmg/Cursor.app',
           'requirement': 'identifier "com.todesktop.230313mzl4w4u92" and '
                          'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'VDXQ22DGB9'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.peetinc.download.Cursor/downloads/Cursor.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.5un1YW/Cursor.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.5un1YW/Cursor.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.5un1YW/Cursor.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.peetinc.download.Cursor/downloads/Cursor.dmg/Cursor.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.peetinc.download.Cursor/downloads/Cursor.dmg
Versioner: Found version 1.6.35 in file ~/Library/AutoPkg/Cache/com.github.peetinc.download.Cursor/downloads/Cursor.dmg/Cursor.app/Contents/Info.plist
{'Output': {'version': '1.6.35'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.peetinc.download.Cursor/receipts/Cursor.download.recipe-receipt-20250922-162717.plist

The following new items were downloaded:
    Download Path                                                                                 
    -------------                                                                                 
    ~/Library/AutoPkg/Cache/com.github.peetinc.download.Cursor/downloads/Cursor.dmg 
```