### PR TITLE
Update bazelisk

### DIFF
--- a/Bazel/bazelisk.download.recipe.yaml
+++ b/Bazel/bazelisk.download.recipe.yaml
@@ -2,7 +2,7 @@ Identifier: com.github.discentem.bazelisk.download.yaml
 MinimumVersion: '2.3'
 
 Input:
-  RE_PATTERN: bazelisk-darwin-arm64
+  RE_PATTERN: bazelisk-darwin
 Process:
   - Processor: GitHubReleasesInfoProvider
     Arguments:

--- a/Bazel/bazelisk.download.recipe.yaml
+++ b/Bazel/bazelisk.download.recipe.yaml
@@ -10,5 +10,6 @@ Process:
       asset_regex: '%RE_PATTERN%'
   - Processor: URLDownloader
     Arguments:
+      filename: 'bazelisk'
       url: '%url%'
   - Processor: EndOfCheckPhase

--- a/Bazel/bazelisk.pkg.recipe.yaml
+++ b/Bazel/bazelisk.pkg.recipe.yaml
@@ -15,23 +15,14 @@ Process:
     Arguments:
       source_path: '%pathname%'
       destination_path: '%pkgroot%/usr/local/bin/bazelisk'
-  # create scripts dir
-  - Processor: PkgRootCreator
-    Arguments:
-      pkgroot: '%RECIPE_CACHE_DIR%/%NAME%/scripts'
-  # create postinstall
-  - Processor: FileCreator
-    Arguments:
-      file_path: '%RECIPE_CACHE_DIR%/%NAME%/scripts/postinstall'
-      file_content: |
-        #!/bin/bash
-        chmod +x /usr/local/bin/bazelisk
-      file_mode: '0755'
   - Processor: PkgCreator
     Arguments:
       pkg_request:
         pkgroot: '%RECIPE_CACHE_DIR%/%NAME%/pkgroot'
         pkgname: '%NAME%-%version%'
         id: 'com.github.bazelbuild.bazelisk'
-        # scripts is automatically looking relative to %RECIPE_CACHE_DIR%
-        scripts: '%NAME%/scripts'
+        chown:
+          - path: "/usr/local/bin/bazelisk"
+            user: root
+            group: wheel
+            mode: "0755"

--- a/Bazel/bazelisk.pkg.recipe.yaml
+++ b/Bazel/bazelisk.pkg.recipe.yaml
@@ -8,7 +8,7 @@ Input:
 Process:
   - Processor: PkgRootCreator
     Arguments:
-      pkgroot: '%RECIPE_CACHE_DIR%/%NAME%/pkgroot'
+      pkgroot: '%RECIPE_CACHE_DIR%/pkgroot'
       pkgdirs:
         'usr/local/bin': '0775'
   - Processor: Copier
@@ -18,7 +18,7 @@ Process:
   - Processor: PkgCreator
     Arguments:
       pkg_request:
-        pkgroot: '%RECIPE_CACHE_DIR%/%NAME%/pkgroot'
+        pkgroot: '%RECIPE_CACHE_DIR%/pkgroot'
         pkgname: '%NAME%-%version%'
         id: 'com.github.bazelbuild.bazelisk'
         chown:


### PR DESCRIPTION
This makes two changes:

The download recipe is updated to grab the universal version of bazelisk instead of the arm64 version.

The package recipe is updated to remove the need for a postinstall script by setting the file permissions correctly when the package is built.

-vvv run
[bazelisk.log](https://github.com/user-attachments/files/22628738/bazelisk.log)


