### PR TITLE
Update bazelisk.munki.recipe.yaml

### DIFF
--- a/Bazel/bazelisk.munki.recipe.yaml
+++ b/Bazel/bazelisk.munki.recipe.yaml
@@ -11,13 +11,23 @@ Input:
       - production
     category: '%MUNKI_CATEGORY%'
     description: Bazelisk is a wrapper for Bazel written in Go. It automatically picks a good version of Bazel given your current working directory, downloads it from the official server (if required) and then transparently passes through all command-line arguments to the real Bazel binary. You can call it just like you would call Bazel.
-    developer: Gooogle
+    developer: Google
     display_name: Bazelisk
     name: '%NAME%'
     unattended_install: true
 
 Process:
+  - Processor: MunkiInstallsItemsCreator
+    Arguments:
+      faux_root: '%RECIPE_CACHE_DIR%/pkgroot'
+      installs_item_paths:
+        - /usr/local/bin/bazelisk
+  - Processor: MunkiPkginfoMerger
   - Processor: MunkiImporter
     Arguments:
       pkg_path: '%pkg_path%'
       repo_subdirectory: '%MUNKI_REPO_SUBDIR%'
+  - Processor: PathDeleter
+    Arguments:
+      path_list:
+        - '%RECIPE_CACHE_DIR%/pkgroot/'


### PR DESCRIPTION
This fixes a typo in the developer, but also adds the creation of a Munki installs array and some cleanup at the end.

I opened this as a separate PR from #28 because I know not everyone likes an installs array on items like this just in case.

-vv run
[bazelisk.log](https://github.com/user-attachments/files/22917023/bazelisk.log)
