### PR TITLE
20251122-fix-endofcheckphase

### DIFF
--- a/Acrolinx/Acrolinx.download.recipe.yaml
+++ b/Acrolinx/Acrolinx.download.recipe.yaml
@@ -15,6 +15,8 @@ Process:
   Arguments:
     filename: Acrolinx.zip
 
+- Processor: EndOfCheckPhase
+
 - Processor: Unarchiver
   Arguments:
     archive_path: '%pathname%' # output of URLDownloader

--- a/Cursor/Cursor.download.recipe.yaml
+++ b/Cursor/Cursor.download.recipe.yaml
@@ -17,6 +17,7 @@ Process:
   Arguments:
     filename: '%NAME%.dmg'
     url: '%final_url%'
+- Processor: EndOfCheckPhase
 - Processor: CodeSignatureVerifier
   Arguments:
     input_path: '%pathname%/Cursor.app'


### PR DESCRIPTION
In order to use AutoPkg with the `--check` argument, download recipes must include an `EndOfCheckPhase` processor. This processor indicates where to stop processing when checking for new downloaded files. The proper placement of the processor is directly after the last `URLDownloader` or `URLDownloaderPython` processor to eliminate unnecessary processing (such as a code signature verification of an unchanged file).

This pull request adds the `EndOfCheckPhase` processor if is is missing and moves it to the correct location if it already exists.

Thanks for considering!

This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0.